### PR TITLE
Should add the jar itself to the Java classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ URL = ['https://repo1.maven.org/maven2/com/diffplug/matsim/matconsolectl/' versi
 filename = [tempdir '/matconsolectl-' version '.jar'];
 websave(filename,URL);
 % add it to the path
-javaaddpath([pwd '\' tempdir]);
+javaaddpath([pwd '\' filename]);
 
 % run it
 matlabcontrol.demo.DemoMain


### PR DESCRIPTION
The code to execute the demo initially did not work for me in MATLAB 2015b. Adding the jar file instead of the jar file's location helped.